### PR TITLE
Add flipping information cards on account

### DIFF
--- a/web/lib/HabitatAccount.js
+++ b/web/lib/HabitatAccount.js
@@ -82,6 +82,83 @@ const ACCOUNT_TRANSFER_TEMPLATE =
 <a target='_blank'></a>
 `;
 
+const SVG_INFO_ICON =
+`
+<svg class="info-svg" width="24px" height="24px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M11.9584 4.25H12.0416C13.4108 4.24999 14.4957 4.24999 15.3621 4.33812C16.2497 4.42841 16.9907 4.61739 17.639 5.05052C18.1576 5.39707 18.6029 5.84239 18.9495 6.36104C19.3826 7.00926 19.5716 7.7503 19.6619 8.63794C19.75 9.5043 19.75 10.5892 19.75 11.9584V12.0416C19.75 13.4108 19.75 14.4957 19.6619 15.3621C19.5716 16.2497 19.3826 16.9907 18.9495 17.639C18.6029 18.1576 18.1576 18.6029 17.639 18.9495C16.9907 19.3826 16.2497 19.5716 15.3621 19.6619C14.4957 19.75 13.4108 19.75 12.0416 19.75H11.9584C10.5892 19.75 9.5043 19.75 8.63794 19.6619C7.7503 19.5716 7.00926 19.3826 6.36104 18.9495C5.84239 18.6029 5.39707 18.1576 5.05052 17.639C4.61739 16.9907 4.42841 16.2497 4.33812 15.3621C4.24999 14.4957 4.24999 13.4108 4.25 12.0416V11.9584C4.24999 10.5892 4.24999 9.5043 4.33812 8.63794C4.42841 7.7503 4.61739 7.00926 5.05052 6.36104C5.39707 5.84239 5.84239 5.39707 6.36104 5.05052C7.00926 4.61739 7.7503 4.42841 8.63794 4.33812C9.5043 4.24999 10.5892 4.24999 11.9584 4.25ZM11.1464 8.14645C11 8.29289 11 8.5286 11 9C11 9.4714 11 9.70711 11.1464 9.85355C11.2929 10 11.5286 10 12 10C12.4714 10 12.7071 10 12.8536 9.85355C13 9.70711 13 9.4714 13 9C13 8.5286 13 8.29289 12.8536 8.14645C12.7071 8 12.4714 8 12 8C11.5286 8 11.2929 8 11.1464 8.14645ZM11.1464 11.1464C11 11.2929 11 11.5286 11 12V15C11 15.4714 11 15.7071 11.1464 15.8536C11.2929 16 11.5286 16 12 16C12.4714 16 12.7071 16 12.8536 15.8536C13 15.7071 13 15.4714 13 15V12C13 11.5286 13 11.2929 12.8536 11.1464C12.7071 11 12.4714 11 12 11C11.5286 11 11.2929 11 11.1464 11.1464Z" fill="black"/>
+</svg>
+`;
+
+const ACCOUNT_GAS_TANK_CARD_TEMPLATE =
+`
+<div class='flip-card' style='grid-row:1/1;grid-column:2/2;'>
+  <div id='wrapper-gas' class='flip-wrapper'>
+    <div class='left box flip-card-front'>
+      <h6 class='spaced-title'><span>⛽️ Gas Tank Balance</span><em target='wrapper-gas' class='icon-info'>${SVG_INFO_ICON}</em></h6>
+      <space></space>
+      <div style='display:grid;grid-template-rows:1fr 1fr;'>
+        <div>
+          <h1 id='gasTankBalance'> </h1>
+          <p class='smaller' style='color:var(--color-grey);'>Estimated price per Transaction: <span id='ratePerTx'></span></p>
+          <p class='smaller' style='color:var(--color-grey);'>For roundabout <span id='gasTankRemaining'></span> Transactions.</p>
+        </div>
+        <div style='place-self:end left;'>
+          <p class='smaller' style='color:var(--color-grey);'>⚠️ You can't remove balance from gas tank.</p>
+        </div>
+      </div>
+    </div>
+    <div class='left box flip-card-back'>
+      <h6 class='right-title'><em target='wrapper-gas' class='icon-info icon-flip'>${SVG_INFO_ICON}</em></h6>
+      <p class='info-text'>To secure the network and all the user and community funds the Habitat rollup needs Gas to operate.</p>
+      <p class='info-text'>Like a pre-paid phone the user tops up it's balance to interact with all features, modules and functionalities.</p>
+      <p class='info-text'>A 1% top-up fee is taken and distributed among all HBT stakers/deposits.</p>
+    </div>
+  </div>
+</div>
+`;
+
+const ACCOUNT_YIELD_CARD_TEMPLATE =
+`
+<div class='flip-card' style='grid-row:1/1;grid-column:3/3;'>
+  <div id='wrapper-yield' class='flip-wrapper'>
+    <div class='left box flip-card-front'>
+      <h6 class='spaced-title'><span>💸 Rollup Yield </span><em target='wrapper-yield' class='icon-info'>${SVG_INFO_ICON}</em></h6>
+      <space></space>
+      <div style='display:grid;grid-template-columns:repeat(2, 1fr);gap:.7em;'>
+        <div>
+          <div class='flex row' style='flex-wrap:nowrap;'>
+            <h1 style='white-space:pre;' id='rewardYield'> </h1>
+          </div>
+          <space></space>
+          <button id='claim' class='boxBtn'>Claim</button>
+          <space></space>
+          <p class='smaller' style='color:var(--color-grey);'>Next yield added in <span id='nextYield'></span></p>
+        </div>
+        <div>
+          <p style='color:var(--color-grey);' class='smaller'>Your Stake:</p>
+          <p id='stake'> </p>
+          <space></space>
+
+          <p style='color:var(--color-grey);' class='smaller'>Your Share in the Pool:</p>
+          <p id='yieldShare'> </p>
+          <space></space>
+
+          <p style='color:var(--color-grey);' class='smaller'>Estimated Yield Per Epoch:</p>
+          <p id='yield'> </p>
+          <space></space>
+
+          <p class='smaller' style='color:var(--color-grey);'>Rewards earned based on deposited HBT amount and Rollup activity.</p>
+        </div>
+      </div>
+    </div>
+    <div class='left box flip-card-back'>
+      <h6 class='right-title'><em target='wrapper-yield' class='icon-info icon-flip'>${SVG_INFO_ICON}</em></h6>
+      <p>The Habitat rollup is generating profits based on the activity and usage of the network. These profits are fairly distributed among all users and their individual amout of deposited HBT tokens on the rollup.</p>
+      <p>The exact yield is depending on the fees earned during one epoch. An epoch is 7 days long. When you withdraw HBT before the epoch ends you won’t get any yield!</p>
+    </div>
+  </div>
+</div>
+`;
 const ACCOUNT_TEMPLATE =
 `
 <style>
@@ -127,6 +204,62 @@ const ACCOUNT_TEMPLATE =
   visibility: visible;
   opacity: 1;
 }
+
+.spaced-title {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+.right-title {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.flip-card {
+  perspective: 40em;
+  padding: 1em;
+}
+
+.flip-wrapper {
+  display: flex;
+  min-height: 15em;
+  transition: transform 0.8s;
+  transform-style: preserve-3d;
+}
+
+.flip-card-front, .flip-card-back {
+  position: absolute;
+  margin-left: 0;
+  width: 100%;
+  height: 100%;
+  -webkit-backface-visibility: hidden; /* Safari */
+  backface-visibility: hidden;
+}
+
+.flip-card-back {
+  color: var(--color-text-invert);
+  transform: rotateY(180deg);
+  background-color: var(--color-bg-invert);
+}
+
+.flip-card-back > p {
+  color: var(--color-text-invert);
+  margin-top: 1rem !important;
+  font-size: 1rem;  
+}
+
+.flip {
+  transform: rotateY(180deg);
+}
+
+.icon-info > svg > path {
+  fill: var(--color-text);
+}
+
+.icon-flip > svg > path {
+  fill: var(--color-text-invert) !important;
+}
+
 </style>
 <section style='background-color:var(--color-bg-yellow);min-height:100%;'>
 <div class='flex row' style='justify-content:space-between;width:100%;min-height:4em;'>
@@ -196,51 +329,9 @@ const ACCOUNT_TEMPLATE =
           <habitat-transfer-box id='transfer-box'></habitat-transfer-box>
         </div>
 
-        <div class='left box' style='grid-row:1/1;grid-column:2/2;'>
-          <h6>⛽️ Gas Balance</h6>
-          <space></space>
-          <div style='display:grid;grid-template-rows:1fr 1fr;'>
-            <div>
-              <h1 id='gasTankBalance'> </h1>
-              <p class='smaller' style='color:var(--color-grey);'>Estimated price per Transaction: <span id='ratePerTx'></span></p>
-              <p class='smaller' style='color:var(--color-grey);'>For roundabout <span id='gasTankRemaining'></span> Transactions.</p>
-            </div>
-            <div style='place-self:end left;'>
-              <p class='smaller' style='color:var(--color-grey);'>⚠️ You can't remove balance from gas tank.</p>
-            </div>
-          </div>
-        </div>
+        ${ACCOUNT_GAS_TANK_CARD_TEMPLATE}
 
-        <div class='left box' style='grid-row:1/1;grid-column:3/3;'>
-          <h6>💸 Yield</h6>
-          <space></space>
-          <div style='display:grid;grid-template-columns:repeat(2, 1fr);gap:.7em;'>
-            <div>
-              <div class='flex row' style='flex-wrap:nowrap;'>
-                <h1 style='white-space:pre;' id='rewardYield'> </h1>
-              </div>
-              <space></space>
-              <button id='claim' class='boxBtn'>Claim</button>
-              <space></space>
-              <p class='smaller' style='color:var(--color-grey);'>Next yield added in <span id='nextYield'></span></p>
-            </div>
-            <div>
-              <p style='color:var(--color-grey);' class='smaller'>Your Stake:</p>
-              <p id='stake'> </p>
-              <space></space>
-
-              <p style='color:var(--color-grey);' class='smaller'>Your Share in the Pool:</p>
-              <p id='yieldShare'> </p>
-              <space></space>
-
-              <p style='color:var(--color-grey);' class='smaller'>Estimated Yield Per Epoch:</p>
-              <p id='yield'> </p>
-              <space></space>
-
-              <p class='smaller' style='color:var(--color-grey);'>Rewards earned based on deposited HBT amount and Rollup activity.</p>
-            </div>
-          </div>
-        </div>
+        ${ACCOUNT_YIELD_CARD_TEMPLATE}
 
         <div class='left box' style='grid-row:2/4;grid-column:2/4;'>
           <h6>🏕 Rollup Balances</h6>
@@ -463,6 +554,16 @@ class HabitatAccount extends HabitatPanel {
         );
       }
     );
+
+    for (const e of this.shadowRoot.querySelectorAll('em.icon-info')) {
+      wrapListener(e, () => {
+        const wrapper = this.shadowRoot.querySelector(`#${e.getAttribute('target')}`);
+        wrapper.classList.toggle('flip');
+        setTimeout(() => {
+          wrapper.classList.remove('flip');
+        }, 5000); // return to front side of card
+      });
+    }
 
     this.updateAccount();
   }

--- a/web/lib/HabitatSidebar.js
+++ b/web/lib/HabitatSidebar.js
@@ -75,6 +75,23 @@ const NAV_TEMPLATE =
   text-decoration: underline;
 }
 
+.settings {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  width: 100%;
+  font-size: 0.7em;
+  padding-bottom: 0.7em;
+}
+
+.settings > span {
+  align-self: center;
+}
+
+.color-toggle {
+  transform: none;
+}
+
 </style>
 <div class='sidebar'>
   <div id='top'>
@@ -135,7 +152,10 @@ const NAV_TEMPLATE =
       </div>
     </div>
     <space></space>
-    <habitat-color-toggle style='position:relative;padding-bottom:1.5em;transform:none;'></habitat-color-toggle>
+    <div class='settings'>
+      <span><a href='#habitat-account'> ⚙ User Settings</a></span>
+      <span><habitat-color-toggle class='color-toggle'></habitat-color-toggle></span>
+    </div>
   </div>
 </div>`;
 

--- a/web/lib/assets/base.css
+++ b/web/lib/assets/base.css
@@ -25,7 +25,7 @@ habitat-color-toggle {
 }
 
 div#colorSchemeToggle {
-  font-size: 30px;
+  font-size: 1.5em;
   width: 32px;
   height: 32px;
   overflow: hidden;

--- a/web/lib/assets/color.css
+++ b/web/lib/assets/color.css
@@ -14,6 +14,7 @@
   --color-red: #c71585;
   --color-green: #66cdaa;
   --color-text: #202020;
+  --color-text-invert: #ffffff;
   --color-bg: #ffffff;
   --color-bg-invert: #202020;
   --color-error: #eb4d62;
@@ -32,6 +33,7 @@
   --color-brand3: #404050;
   --color-brand4: #604050;
   --color-text: #ffffff;
+  --color-text-invert: #202020;
   --color-bg: #202020;
   --color-bg-invert: #ffffff;
   --border-radius-frame: 6px;


### PR DESCRIPTION
- Adds User settings link on sidebar loads `#habitat-account`
- Reduces font-size of color toggle icons to have entire icon visible
- Adds information icon to gas and yield accounts
- Clicked information cards flips display between text and data
- Card flips back to data after 5 seconds 